### PR TITLE
Pterodactyl Client

### DIFF
--- a/app/Console/Commands/PterodactylProvisionServer.php
+++ b/app/Console/Commands/PterodactylProvisionServer.php
@@ -1,0 +1,138 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\EggMetadata;
+use App\Services\Pterodactyl\PterodactylClient;
+use Illuminate\Console\Command;
+
+class PterodactylProvisionServer extends Command
+{
+    protected $signature = 'pterodactyl:provision-server {--dry-run}';
+    protected $description = 'Interactively provision a server on Pterodactyl for testing';
+
+    public function handle(PterodactylClient $ptero): int
+    {
+        $firstName = $this->ask('User first name');
+        $lastName = $this->ask('User last name');
+        $email = $this->ask('User email');
+
+        $serverName = $this->ask('Server name');
+
+        $nestId = (int) $this->ask('Nest ID');
+        $eggId = (int) $this->ask('Egg ID');
+        $nodeId = (int) $this->ask('Node ID');
+
+        $memory = (int) $this->ask('Memory (MB)');
+        $swap = (int) $this->ask('Swap (MB)');
+        $disk = (int) $this->ask('Disk (MB)');
+        $cpu = (int) $this->ask('CPU (%)');
+        $io = 500;
+
+        $databases = (int) $this->ask('Feature limit: databases', 1);
+        $allocations = (int) $this->ask('Feature limit: allocations', 1);
+        $backups = (int) $this->ask('Feature limit: backups', 1);
+
+        $eggMeta = EggMetadata::where('nest_id', $nestId)
+            ->where('egg_id', $eggId)
+            ->where('is_active', true)
+            ->first();
+
+        if (!$eggMeta) {
+            $this->error('Missing per-egg metadata. Please insert environment and port range for this egg first.');
+            return self::FAILURE;
+        }
+
+        $eggDetails = $ptero->getEggDetails($nestId, $eggId);
+        $startup = $eggDetails['startup'] ?? null;
+        $dockerImage = $eggDetails['docker_image'] ?? null;
+
+        if (!$startup || !$dockerImage) {
+            $this->error('Egg details missing startup or docker_image; cannot proceed.');
+            return self::FAILURE;
+        }
+
+        $allocationId = $ptero->findFirstFreeAllocationInRange($nodeId, (int) $eggMeta->port_min, (int) $eggMeta->port_max);
+        if (!$allocationId) {
+            $this->error('No free allocation found on the node within the egg\'s port range.');
+            return self::FAILURE;
+        }
+
+        $environment = $eggMeta->environment_json ?? [];
+        if (!is_array($environment) || empty($environment)) {
+            $this->error('Egg environment is empty; provisioning would fail.');
+            return self::FAILURE;
+        }
+
+        // Resolve existing user id for review (no changes yet)
+        $existingUserId = $ptero->findUserByEmail($email);
+
+        $this->line('Review:');
+        if (!$existingUserId) {
+            $this->info('User not found; a new user will be created with:');
+            // Mirror client formatting so the review matches the eventual request
+            $formattedUsername = (new \ReflectionClass($ptero))->getMethod('createUser')->isPublic() ? str_replace('@', '_', $email) : str_replace('@', '_', $email);
+            $userCreatePayload = [
+                'email' => $email,
+                'username' => $formattedUsername,
+                'first_name' => $firstName,
+                'last_name' => $lastName,
+            ];
+            $this->output->writeln(json_encode($userCreatePayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+        } else {
+            $this->info('User found: id = ' . $existingUserId);
+        }
+
+        $serverPayload = [
+            'name' => $serverName,
+            'user' => $existingUserId ?: '(to be created)',
+            'egg' => $eggId,
+            'docker_image' => $dockerImage,
+            'startup' => $startup,
+            'environment' => $environment,
+            'limits' => [
+                'memory' => $memory,
+                'swap' => $swap,
+                'disk' => $disk,
+                'io' => $io,
+                'cpu' => $cpu,
+            ],
+            'feature_limits' => [
+                'databases' => $databases,
+                'allocations' => $allocations,
+                'backups' => $backups,
+            ],
+            'allocation' => [
+                'default' => $allocationId,
+            ],
+        ];
+
+        $this->info('Server create payload:');
+        $this->output->writeln(json_encode($serverPayload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        if (!$this->option('dry-run')) {
+            if (!$this->confirm('Proceed with provisioning?', true)) {
+                $this->warn('Aborted by user.');
+                return self::SUCCESS;
+            }
+        }
+
+        if ($this->option('dry-run')) {
+            $this->info('Dry-run complete.');
+            return self::SUCCESS;
+        }
+
+        $userId = $existingUserId ?? $ptero->createUser($email, $firstName, $lastName);
+
+        // Final payload with concrete user id
+        $serverPayload['user'] = $userId;
+        $result = $ptero->createServer($serverPayload);
+
+        $this->info('Provisioned successfully. Response:');
+        $this->output->writeln(json_encode($result, JSON_PRETTY_PRINT));
+
+        return self::SUCCESS;
+    }
+}
+
+

--- a/app/Models/EggMetadata.php
+++ b/app/Models/EggMetadata.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class EggMetadata extends Model
+{
+    use HasFactory;
+
+    protected $table = 'egg_metadata';
+
+    protected $fillable = [
+        'nest_id',
+        'nest_name',
+        'egg_id',
+        'egg_name',
+        'port_min',
+        'port_max',
+        'environment_json',
+        'is_active',
+    ];
+
+    protected $casts = [
+        'environment_json' => 'array',
+        'is_active' => 'boolean',
+    ];
+}
+
+

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -3,6 +3,7 @@
 namespace App\Providers;
 
 use Illuminate\Support\ServiceProvider;
+use App\Console\Commands\PterodactylProvisionServer;
 
 class AppServiceProvider extends ServiceProvider
 {
@@ -19,6 +20,10 @@ class AppServiceProvider extends ServiceProvider
      */
     public function boot(): void
     {
-        //
+        if ($this->app->runningInConsole()) {
+            $this->commands([
+                PterodactylProvisionServer::class,
+            ]);
+        }
     }
 }

--- a/app/Services/Config/ConfigService.php
+++ b/app/Services/Config/ConfigService.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Services\Config;
+
+use InvalidArgumentException;
+
+class ConfigService
+{
+    public function get(string $key): mixed
+    {
+        $value = config($key);
+        if ($value === null || $value === '') {
+            throw new InvalidArgumentException("Missing required configuration value for key: {$key}");
+        }
+        return $value;
+    }
+}
+
+

--- a/app/Services/Pterodactyl/PterodactylClient.php
+++ b/app/Services/Pterodactyl/PterodactylClient.php
@@ -1,0 +1,191 @@
+<?php
+
+namespace App\Services\Pterodactyl;
+
+use App\Services\Config\ConfigService;
+use GuzzleHttp\Client as HttpClient;
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Log\LoggerInterface;
+
+class PterodactylClient
+{
+    private HttpClient $http;
+    private string $baseUrl;
+    private LoggerInterface $logger;
+
+    public function __construct(ConfigService $config, LoggerInterface $logger)
+    {
+        $this->baseUrl = rtrim($config->get('pterodactyl.base_url'), '/');
+        $apiKey = $config->get('pterodactyl.app_api_key');
+        $this->logger = $logger;
+
+        $this->http = new HttpClient([
+            'base_uri' => $this->baseUrl,
+            'headers' => [
+                'Authorization' => 'Bearer ' . $apiKey,
+                'Accept' => 'Application/vnd.pterodactyl.v1+json',
+                'Content-Type' => 'application/json',
+            ],
+            'http_errors' => false,
+            'timeout' => 30,
+        ]);
+    }
+
+    private function logRequest(string $method, string $uri, array $options = []): void
+    {
+        $redacted = $options;
+        // Avoid logging auth header; we set it globally.
+        $this->logger->info('[Ptero] Request', [
+            'method' => $method,
+            'uri' => $uri,
+            'options' => $redacted,
+        ]);
+    }
+
+    private function logResponse(int $status, string $body): void
+    {
+        $this->logger->info('[Ptero] Response', [
+            'status' => $status,
+            'body' => $body,
+        ]);
+    }
+
+    private function request(string $method, string $uri, array $options = []): array
+    {
+        $this->logRequest($method, $uri, $options);
+        try {
+            $response = $this->http->request($method, $uri, $options);
+        } catch (GuzzleException $e) {
+            $this->logger->error('[Ptero] HTTP error', ['error' => $e->getMessage()]);
+            throw $e;
+        }
+
+        $status = $response->getStatusCode();
+        $body = (string) $response->getBody();
+        $this->logResponse($status, $body);
+
+        $json = json_decode($body, true);
+        return [
+            'status' => $status,
+            'body' => $body,
+            'json' => $json,
+        ];
+    }
+
+    // Users
+    public function findUserByEmail(string $email): ?int
+    {
+        $res = $this->request('GET', '/api/application/users', [
+            'query' => [
+                'search' => $email,
+            ],
+        ]);
+
+        if ($res['status'] >= 400 || !isset($res['json']['data'])) {
+            return null;
+        }
+        foreach ($res['json']['data'] as $item) {
+            if (($item['attributes']['email'] ?? '') === $email) {
+                return (int) $item['attributes']['id'];
+            }
+        }
+        return null;
+    }
+
+    public function createUser(string $email, string $firstName, string $lastName): int
+    {
+        $username = $this->formatUsernameFromEmail($email);
+        $payload = [
+            'email' => $email,
+            'username' => $username,
+            'first_name' => $firstName,
+            'last_name' => $lastName,
+            // No password: let panel send welcome/reset
+        ];
+
+        $res = $this->request('POST', '/api/application/users', [
+            'json' => $payload,
+        ]);
+        if ($res['status'] < 200 || $res['status'] >= 300) {
+            throw new \RuntimeException('Failed to create user: ' . $res['body']);
+        }
+        return (int) ($res['json']['attributes']['id'] ?? 0);
+    }
+
+    private function formatUsernameFromEmail(string $email): string
+    {
+        // Temporary rule: replace '@' with '_' and strip unsupported characters.
+        // Allowed: letters, numbers, dashes, underscores, periods.
+        $candidate = str_replace('@', '_', $email);
+        $candidate = preg_replace('/[^A-Za-z0-9._-]/', '', $candidate) ?? '';
+        // Ensure starts/ends with alphanumeric by trimming non-alnum at ends.
+        $candidate = preg_replace('/^[^A-Za-z0-9]+|[^A-Za-z0-9]+$/', '', $candidate) ?? '';
+        // Fallback if becomes empty
+        if ($candidate === '') {
+            $candidate = 'user' . substr(md5($email), 0, 8);
+        }
+        return $candidate;
+    }
+
+    // Eggs
+    public function getEggDetails(int $nestId, int $eggId): array
+    {
+        $res = $this->request('GET', "/api/application/nests/{$nestId}/eggs/{$eggId}");
+        if ($res['status'] < 200 || $res['status'] >= 300) {
+            throw new \RuntimeException('Failed to fetch egg details: ' . $res['body']);
+        }
+        return $res['json']['attributes'] ?? [];
+    }
+
+    // Nodes & allocations
+    public function listNodeAllocations(int $nodeId, int $page = 1): array
+    {
+        $res = $this->request('GET', "/api/application/nodes/{$nodeId}/allocations", [
+            'query' => [
+                'page' => $page,
+                'per_page' => 100,
+            ],
+        ]);
+        if ($res['status'] < 200 || $res['status'] >= 300) {
+            throw new \RuntimeException('Failed to list allocations: ' . $res['body']);
+        }
+        return $res['json'];
+    }
+
+    public function findFirstFreeAllocationInRange(int $nodeId, int $portMin, int $portMax): ?int
+    {
+        $page = 1;
+        while (true) {
+            $data = $this->listNodeAllocations($nodeId, $page);
+            $items = $data['data'] ?? [];
+            foreach ($items as $item) {
+                $attr = $item['attributes'] ?? [];
+                $port = (int) ($attr['port'] ?? 0);
+                $assigned = (bool) ($attr['assigned'] ?? false);
+                if (!$assigned && $port >= $portMin && $port <= $portMax) {
+                    return (int) $attr['id'];
+                }
+            }
+            $meta = $data['meta']['pagination'] ?? null;
+            if (!$meta || $meta['current_page'] >= $meta['total_pages']) {
+                break;
+            }
+            $page++;
+        }
+        return null;
+    }
+
+    // Servers
+    public function createServer(array $payload): array
+    {
+        $res = $this->request('POST', '/api/application/servers', [
+            'json' => $payload,
+        ]);
+        if ($res['status'] < 200 || $res['status'] >= 300) {
+            throw new \RuntimeException('Failed to create server: ' . $res['body']);
+        }
+        return $res['json'];
+    }
+}
+
+

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
     "license": "MIT",
     "require": {
         "php": "^8.2",
+        "guzzlehttp/guzzle": "^7.10",
         "laravel/framework": "^12.0",
         "laravel/tinker": "^2.10.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c514d8f7b9fc5970bdd94287905ef584",
+    "content-hash": "f48ffe1bb7b037f2a655d7ee4e7e733a",
     "packages": [
         {
             "name": "brick/math",

--- a/config/pterodactyl.php
+++ b/config/pterodactyl.php
@@ -1,0 +1,8 @@
+<?php
+
+return [
+    'base_url' => env('PTERO_BASE_URL'),
+    'app_api_key' => env('PTERO_APP_API_KEY'),
+];
+
+

--- a/database/migrations/2025_08_26_000000_create_egg_metadata_table.php
+++ b/database/migrations/2025_08_26_000000_create_egg_metadata_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('egg_metadata', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedBigInteger('nest_id');
+            $table->string('nest_name');
+            $table->unsignedBigInteger('egg_id');
+            $table->string('egg_name');
+            $table->unsignedInteger('port_min');
+            $table->unsignedInteger('port_max');
+            $table->json('environment_json');
+            $table->boolean('is_active')->default(true);
+            $table->timestamps();
+
+            $table->unique(['nest_id', 'egg_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('egg_metadata');
+    }
+};
+
+


### PR DESCRIPTION
feat(pterodactyl): add provisioning POC with interactive Artisan command
- Install guzzlehttp/guzzle for HTTP requests
- Add ConfigService and config/pterodactyl.php to centralize config access (no direct env())
- Create egg_metadata table/model storing per-egg environment and port range
- Implement PterodactylClient (users, eggs, nodes/allocations, server create) with request/response logging
- Select first unassigned node allocation within the egg’s port range
- Add `pterodactyl:provision-server` interactive command with review and --dry-run
- Fetch `startup` and `docker_image` live from egg details; use env from egg_metadata; fail fast if missing
- Create user without password to trigger panel email; temp username rule: replace '@' with '_' and sanitize
- Default IO=500; prompt for memory/swap/disk/cpu and feature_limits (databases/allocations/backups)
- Register command and run initial migrations